### PR TITLE
Distinguish members storage from clubbook

### DIFF
--- a/src/main/java/seedu/club/MainApp.java
+++ b/src/main/java/seedu/club/MainApp.java
@@ -59,7 +59,7 @@ public class MainApp extends Application {
         UserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(config.getUserPrefsFilePath());
         UserPrefs userPrefs = initPrefs(userPrefsStorage);
         ClubBookStorage clubBookStorage = new JsonClubBookStorage(
-                userPrefs.getClubBookFilePath(),
+                userPrefs.getMemberStorageFilePath(),
                 userPrefs.getEventStorageFilePath());
         EventStorage eventStorage = (EventStorage) clubBookStorage;
         storage = new StorageManager(clubBookStorage, userPrefsStorage, eventStorage);

--- a/src/main/java/seedu/club/logic/Logic.java
+++ b/src/main/java/seedu/club/logic/Logic.java
@@ -40,7 +40,7 @@ public interface Logic {
     /**
      * Returns the user prefs' club book file path.
      */
-    Path getClubBookFilePath();
+    Path getMemberStorageFilePath();
 
     /**
      * Returns the user prefs' GUI settings.

--- a/src/main/java/seedu/club/logic/LogicManager.java
+++ b/src/main/java/seedu/club/logic/LogicManager.java
@@ -79,8 +79,8 @@ public class LogicManager implements Logic {
     }
 
     @Override
-    public Path getClubBookFilePath() {
-        return model.getClubBookFilePath();
+    public Path getMemberStorageFilePath() {
+        return model.getMemberStorageFilePath();
     }
 
     @Override

--- a/src/main/java/seedu/club/model/Model.java
+++ b/src/main/java/seedu/club/model/Model.java
@@ -41,12 +41,12 @@ public interface Model {
     /**
      * Returns the user prefs' club book file path.
      */
-    Path getClubBookFilePath();
+    Path getMemberStorageFilePath();
 
     /**
      * Sets the user prefs' club book file path.
      */
-    void setClubBookFilePath(Path clubBookFilePath);
+    void setMemberStorageFilePath(Path clubBookFilePath);
 
     /**
      * Replaces club book data with the data in {@code clubBook}.

--- a/src/main/java/seedu/club/model/ModelManager.java
+++ b/src/main/java/seedu/club/model/ModelManager.java
@@ -68,14 +68,14 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public Path getClubBookFilePath() {
-        return userPrefs.getClubBookFilePath();
+    public Path getMemberStorageFilePath() {
+        return userPrefs.getMemberStorageFilePath();
     }
 
     @Override
-    public void setClubBookFilePath(Path clubBookFilePath) {
+    public void setMemberStorageFilePath(Path clubBookFilePath) {
         requireNonNull(clubBookFilePath);
-        userPrefs.setClubBookFilePath(clubBookFilePath);
+        userPrefs.setMemberStorageFilePath(clubBookFilePath);
     }
 
     //=========== ClubBook ================================================================================

--- a/src/main/java/seedu/club/model/ReadOnlyUserPrefs.java
+++ b/src/main/java/seedu/club/model/ReadOnlyUserPrefs.java
@@ -11,7 +11,7 @@ public interface ReadOnlyUserPrefs {
 
     GuiSettings getGuiSettings();
 
-    Path getClubBookFilePath();
+    Path getMemberStorageFilePath();
 
     Path getEventStorageFilePath();
 

--- a/src/main/java/seedu/club/model/UserPrefs.java
+++ b/src/main/java/seedu/club/model/UserPrefs.java
@@ -14,7 +14,7 @@ import seedu.club.commons.core.GuiSettings;
 public class UserPrefs implements ReadOnlyUserPrefs {
 
     private GuiSettings guiSettings = new GuiSettings();
-    private Path clubBookFilePath = Paths.get("data" , "clubbook.json");
+    private Path memberStorageFilePath = Paths.get("data" , "members.json");
     private Path eventStorageFilePath = Paths.get("data", "events.json");
 
     /**
@@ -36,7 +36,7 @@ public class UserPrefs implements ReadOnlyUserPrefs {
     public void resetData(ReadOnlyUserPrefs newUserPrefs) {
         requireNonNull(newUserPrefs);
         setGuiSettings(newUserPrefs.getGuiSettings());
-        setClubBookFilePath(newUserPrefs.getClubBookFilePath());
+        setMemberStorageFilePath(newUserPrefs.getMemberStorageFilePath());
         setEventStorageFilePath(newUserPrefs.getEventStorageFilePath());
     }
 
@@ -49,13 +49,13 @@ public class UserPrefs implements ReadOnlyUserPrefs {
         this.guiSettings = guiSettings;
     }
 
-    public Path getClubBookFilePath() {
-        return clubBookFilePath;
+    public Path getMemberStorageFilePath() {
+        return memberStorageFilePath;
     }
 
-    public void setClubBookFilePath(Path clubBookFilePath) {
-        requireNonNull(clubBookFilePath);
-        this.clubBookFilePath = clubBookFilePath;
+    public void setMemberStorageFilePath(Path memberStorageFilePath) {
+        requireNonNull(memberStorageFilePath);
+        this.memberStorageFilePath = memberStorageFilePath;
     }
 
     public Path getEventStorageFilePath() {
@@ -80,20 +80,20 @@ public class UserPrefs implements ReadOnlyUserPrefs {
 
         UserPrefs otherUserPrefs = (UserPrefs) other;
         return guiSettings.equals(otherUserPrefs.guiSettings)
-                && clubBookFilePath.equals(otherUserPrefs.clubBookFilePath)
+                && memberStorageFilePath.equals(otherUserPrefs.memberStorageFilePath)
                 && eventStorageFilePath.equals(otherUserPrefs.eventStorageFilePath);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(guiSettings, clubBookFilePath, eventStorageFilePath);
+        return Objects.hash(guiSettings, memberStorageFilePath, eventStorageFilePath);
     }
 
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append("Gui Settings : " + guiSettings);
-        sb.append("\nLocal data file location : " + clubBookFilePath);
+        sb.append("\nLocal data file location : " + memberStorageFilePath);
         sb.append("\nLocal event data file location : " + eventStorageFilePath);
         return sb.toString();
     }

--- a/src/main/java/seedu/club/ui/MainWindow.java
+++ b/src/main/java/seedu/club/ui/MainWindow.java
@@ -122,7 +122,7 @@ public class MainWindow extends UiPart<Stage> {
         resultDisplay = new ResultDisplay();
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());
 
-        StatusBarFooter statusBarFooter = new StatusBarFooter(logic.getClubBookFilePath());
+        StatusBarFooter statusBarFooter = new StatusBarFooter(logic.getMemberStorageFilePath());
         statusbarPlaceholder.getChildren().add(statusBarFooter.getRoot());
 
         CommandBox commandBox = new CommandBox(this::executeCommand);

--- a/src/test/data/JsonUserPrefsStorageTest/ExtraValuesUserPref.json
+++ b/src/test/data/JsonUserPrefsStorageTest/ExtraValuesUserPref.json
@@ -9,5 +9,5 @@
       "z" : 99
     }
   },
-  "clubBookFilePath" : "clubbook.json"
+  "memberStorageFilePath" : "members.json"
 }

--- a/src/test/data/JsonUserPrefsStorageTest/TypicalUserPref.json
+++ b/src/test/data/JsonUserPrefsStorageTest/TypicalUserPref.json
@@ -7,5 +7,5 @@
       "y" : 100
     }
   },
-  "clubBookFilePath" : "clubbook.json"
+  "memberStorageFilePath" : "members.json"
 }

--- a/src/test/java/seedu/club/logic/commands/member/AddMemberCommandTest.java
+++ b/src/test/java/seedu/club/logic/commands/member/AddMemberCommandTest.java
@@ -116,12 +116,12 @@ public class AddMemberCommandTest {
         }
 
         @Override
-        public Path getClubBookFilePath() {
+        public Path getMemberStorageFilePath() {
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
-        public void setClubBookFilePath(Path clubBookFilePath) {
+        public void setMemberStorageFilePath(Path memberStorageFilePath) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/club/model/ModelManagerTest.java
+++ b/src/test/java/seedu/club/model/ModelManagerTest.java
@@ -40,14 +40,14 @@ public class ModelManagerTest {
     @Test
     public void setUserPrefs_validUserPrefs_copiesUserPrefs() {
         UserPrefs userPrefs = new UserPrefs();
-        userPrefs.setClubBookFilePath(Paths.get("club/book/file/path"));
+        userPrefs.setMemberStorageFilePath(Paths.get("club/book/file/path"));
         userPrefs.setGuiSettings(new GuiSettings(1, 2, 3, 4));
         modelManager.setUserPrefs(userPrefs);
         assertEquals(userPrefs, modelManager.getUserPrefs());
 
         // Modifying userPrefs should not modify modelManager's userPrefs
         UserPrefs oldUserPrefs = new UserPrefs(userPrefs);
-        userPrefs.setClubBookFilePath(Paths.get("new/club/book/file/path"));
+        userPrefs.setMemberStorageFilePath(Paths.get("new/club/book/file/path"));
         assertEquals(oldUserPrefs, modelManager.getUserPrefs());
     }
 
@@ -64,15 +64,15 @@ public class ModelManagerTest {
     }
 
     @Test
-    public void setClubBookFilePath_nullPath_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> modelManager.setClubBookFilePath(null));
+    public void setMemberStorageFilePath_nullPath_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> modelManager.setMemberStorageFilePath(null));
     }
 
     @Test
-    public void setClubBookFilePath_validPath_setsClubBookFilePath() {
+    public void setMemberStorageFilePath_validPath_setsMemberStorageFilePath() {
         Path path = Paths.get("club/book/file/path");
-        modelManager.setClubBookFilePath(path);
-        assertEquals(path, modelManager.getClubBookFilePath());
+        modelManager.setMemberStorageFilePath(path);
+        assertEquals(path, modelManager.getMemberStorageFilePath());
     }
 
     //=========== Member =============================================================
@@ -132,7 +132,7 @@ public class ModelManagerTest {
 
         // different userPrefs -> returns false
         UserPrefs differentUserPrefs = new UserPrefs();
-        differentUserPrefs.setClubBookFilePath(Paths.get("differentFilePath"));
+        differentUserPrefs.setMemberStorageFilePath(Paths.get("differentFilePath"));
         assertFalse(modelManager.equals(new ModelManager(clubBook, differentUserPrefs)));
     }
 
@@ -195,7 +195,7 @@ public class ModelManagerTest {
 
         // different userPrefs -> returns false
         UserPrefs differentUserPrefs = new UserPrefs();
-        differentUserPrefs.setClubBookFilePath(Paths.get("differentFilePath"));
+        differentUserPrefs.setMemberStorageFilePath(Paths.get("differentFilePath"));
         assertFalse(modelManager.equals(new ModelManager(clubBook, differentUserPrefs)));
     }
 }

--- a/src/test/java/seedu/club/model/UserPrefsTest.java
+++ b/src/test/java/seedu/club/model/UserPrefsTest.java
@@ -13,9 +13,9 @@ public class UserPrefsTest {
     }
 
     @Test
-    public void setClubBookFilePath_nullPath_throwsNullPointerException() {
+    public void setMemberStorageFilePath_nullPath_throwsNullPointerException() {
         UserPrefs userPrefs = new UserPrefs();
-        assertThrows(NullPointerException.class, () -> userPrefs.setClubBookFilePath(null));
+        assertThrows(NullPointerException.class, () -> userPrefs.setMemberStorageFilePath(null));
     }
 
 }

--- a/src/test/java/seedu/club/storage/JsonUserPrefsStorageTest.java
+++ b/src/test/java/seedu/club/storage/JsonUserPrefsStorageTest.java
@@ -73,7 +73,7 @@ public class JsonUserPrefsStorageTest {
     private UserPrefs getTypicalUserPrefs() {
         UserPrefs userPrefs = new UserPrefs();
         userPrefs.setGuiSettings(new GuiSettings(1000, 500, 300, 100));
-        userPrefs.setClubBookFilePath(Paths.get("clubbook.json"));
+        userPrefs.setMemberStorageFilePath(Paths.get("members.json"));
         return userPrefs;
     }
 


### PR DESCRIPTION
closes #138 

As mentioned in the issue, the switch from `AddressBook` to `ClubBook` was not fully complete, `AddressBook` was used to mean both the app and member at the same time, this PR separates the two to prevent confusion.