### PR TITLE
Fix edit event not throwing error

### DIFF
--- a/src/main/java/seedu/club/logic/commands/event/EditEventCommand.java
+++ b/src/main/java/seedu/club/logic/commands/event/EditEventCommand.java
@@ -120,7 +120,8 @@ public class EditEventCommand extends Command {
      * Creates and returns a {@code Event} with the details of {@code eventToEdit}
      * edited with {@code editEventDescriptor}.
      */
-    private static Event createEditedEvent(Event eventToEdit, EditEventDescriptor editEventDescriptor) throws ParseException {
+    private static Event createEditedEvent(
+            Event eventToEdit, EditEventDescriptor editEventDescriptor) throws ParseException {
         assert eventToEdit != null;
 
 


### PR DESCRIPTION
closes #260 

Fixes the error that editting the datetimes of events doesn't handle error when the from is not before to