### PR TITLE
Change phone number requirements

### DIFF
--- a/src/main/java/seedu/club/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/club/logic/parser/ParserUtil.java
@@ -63,7 +63,7 @@ public class ParserUtil {
      */
     public static Phone parsePhone(String phone) throws ParseException {
         requireNonNull(phone);
-        String trimmedPhone = phone.trim();
+        String trimmedPhone = normalizeAndTrimWhitespace(phone);
         if (!Phone.isValidPhone(trimmedPhone)) {
             throw new ParseException(Phone.MESSAGE_CONSTRAINTS);
         }

--- a/src/main/java/seedu/club/model/member/Phone.java
+++ b/src/main/java/seedu/club/model/member/Phone.java
@@ -9,8 +9,10 @@ import static seedu.club.commons.util.AppUtil.checkArgument;
  */
 public class Phone {
     public static final String MESSAGE_CONSTRAINTS =
-            "Phone numbers should be exactly 8 digits long, starting with either 6, 8 or 9.";
-    public static final String VALIDATION_REGEX = "^[689]\\d{7}$";
+            "Phone numbers must be 7-12 digits long with at most one leading zero and cannot be all zeros.\n"
+            + "An optional country code (+1 to +999, no leading zeros) may precede the phone number, "
+            + "separated with a space.\nNo other spaces are allowed.";
+    public static final String VALIDATION_REGEX = "^(?:\\+[1-9]\\d{0,2}\\s)?(?:0[1-9]\\d{5,10}|[1-9]\\d{6,11})$";
     public final String value;
 
     /**


### PR DESCRIPTION
closes #270, message includes a part to mention that `"No spaces are allowed"` within phone numbers or country codes.

closes #275, closes #285, to allow for international phone numbers and slightly more flexible phone numbers.

In particular, now phone numbers take the following format:
Country code: Must be `+1 to +999` without any leading zeros.
Phone number: Must be 7-12 digits long, with at most one leading zero.

Country code and phone number <ins>must</ins> be separated by a whitespace so that ambiguity is avoided. For example, `+6597123456` may be interpreted as `+65 97123456` or `+659 7123456` or `+6 597123456`