### PR TITLE
Remove restriction for find commands

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -736,7 +736,7 @@ testers are expected to do more *exploratory* testing.
 
 1. Finding a member
 
-    1. Prerequisites: List all members using the `listMembers` command. The default sample club book data is used.
+    1. Prerequisites: The default sample club book data is used.
     
     2. Test case: `findMember Alex`<br>
        Expected: Only `Alex Yeoh` is shown. Status message box indicates one member listed.
@@ -749,7 +749,7 @@ testers are expected to do more *exploratory* testing.
 
 2. Finding an event
 
-   1. Prerequisites: List all events using the `listEvents` command. The default sample club book data is used.
+   1. Prerequisites: The default sample club book data is used.
 
    2. Test case: `findEvent Orientation`<br>
       Expected: Only `Orientation` is shown. Status message box indicates one event listed.

--- a/src/main/java/seedu/club/logic/commands/event/FindEventCommand.java
+++ b/src/main/java/seedu/club/logic/commands/event/FindEventCommand.java
@@ -34,14 +34,6 @@ public class FindEventCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        /* Ensure that event list is displaying first, so that the ClubBook does not unintentionally show no
-           results if the user is on member list instead.
-         */
-        if (model.getViewState() != ViewState.EVENT) {
-            throw new CommandException(Messages.MESSAGE_NOT_EVENT_STATE);
-        }
-
-        // The following line is there as a safety measure.
         model.setViewState(ViewState.EVENT);
         model.updateFilteredEventList(predicate);
         return new CommandResult(

--- a/src/main/java/seedu/club/logic/commands/member/FindMemberCommand.java
+++ b/src/main/java/seedu/club/logic/commands/member/FindMemberCommand.java
@@ -35,15 +35,6 @@ public class FindMemberCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        /* Ensure that member list is displaying first, so that the ClubBook does not unintentionally show no
-           results if the user is on event list instead.
-         */
-        if (model.getViewState() != ViewState.MEMBER) {
-            throw new CommandException(Messages.MESSAGE_NOT_MEMBER_STATE);
-        }
-
-        // The following line is technically not necessary since already guaranteed to be on member list,
-        // but is there as a safety measure.
         model.setViewState(ViewState.MEMBER);
         model.updateFilteredMemberList(predicate);
         return new CommandResult(


### PR DESCRIPTION
Remove the restriction for `find` commands that it must be on the corresponding list first.